### PR TITLE
Storm: use .count() instead of length filter

### DIFF
--- a/supysonic/templates/playlists.html
+++ b/supysonic/templates/playlists.html
@@ -28,7 +28,7 @@
 	{% for p in mine %}
 	<tr>
 		<td><a href="{{ url_for('playlist_details', uid = p.id) }}">{{ p.name }}</a></td>
-		<td>{{ p.tracks|length }}</td>
+		<td>{{ p.tracks.count() }}</td>
 		<td><input type="checkbox" disabled="true" {% if p.public %}checked="true"{% endif %} /></td>
 		<td><a href="{{ url_for('playlist_delete', uid = p.id) }}">X</a></td>
 	</tr>


### PR DESCRIPTION
After the switch to Storm, we has to use the method count() for objects of type BoundReferenceSetBase.
