### PR TITLE
Debug server: Use port if provided

### DIFF
--- a/cgi-bin/server.py
+++ b/cgi-bin/server.py
@@ -25,5 +25,5 @@ app = create_application()
 if __name__ == '__main__':
 	if app:
 		import sys
-		app.run(host = sys.argv[1] if len(sys.argv) > 1 else None, debug = True)
+		app.run(host = sys.argv[1] if len(sys.argv) > 1 else None, port = int(sys.argv[2]) if len(sys.argv) > 2 else 5000, debug = True)
 


### PR DESCRIPTION
This is a minor change to `cgi-bin/server.py` to allow the standalone debug server to be run with a port defined alongside the host name address. Example usage: `python cgi-bin/server.py 127.0.0.1 31337` to run the standalone server on 127.0.0.1:31337