### PR TITLE
Support POST requests for API

### DIFF
--- a/supysonic/api/__init__.py
+++ b/supysonic/api/__init__.py
@@ -177,7 +177,7 @@ class ResponseHelper:
 		return str(value)
 
 def get_entity(req, ent, param = 'id'):
-	eid = req.args.get(param)
+	eid = req.values.get(param)
 	if not eid:
 		return False, req.error_formatter(10, 'Missing %s id' % ent.__name__)
 

--- a/supysonic/api/__init__.py
+++ b/supysonic/api/__init__.py
@@ -32,7 +32,7 @@ def set_formatter():
 		return
 
 	"""Return a function to create the response."""
-	(f, callback) = map(request.args.get, ['f', 'callback'])
+	(f, callback) = map(request.values.get, ['f', 'callback'])
 	if f == 'jsonp':
 		# Some clients (MiniSub, Perisonic) set f to jsonp without callback for streamed data
 		if not callback and request.endpoint not in [ 'stream_media', 'cover_art' ]:
@@ -64,7 +64,7 @@ def authorize():
 			request.user = user
 			return
 
-	(username, password) = map(request.args.get, [ 'u', 'p' ])
+	(username, password) = map(request.values.get, [ 'u', 'p' ])
 	if not username or not password:
 		return error
 
@@ -81,7 +81,7 @@ def set_headers(response):
 		return response
 
 	if response.mimetype.startswith('text'):
-		f = request.args.get('f')
+		f = request.values.get('f')
 		response.headers['Content-Type'] = 'application/json' if f in [ 'jsonp', 'json' ] else 'text/xml'
 
 	response.headers['Access-Control-Allow-Origin'] = '*'

--- a/supysonic/api/albums_songs.py
+++ b/supysonic/api/albums_songs.py
@@ -31,8 +31,8 @@ from supysonic.db import now
 
 @app.route('/rest/getRandomSongs.view', methods = [ 'GET', 'POST' ])
 def rand_songs():
-	size = request.args.get('size', '10')
-	genre, fromYear, toYear, musicFolderId = map(request.args.get, [ 'genre', 'fromYear', 'toYear', 'musicFolderId' ])
+	size = request.values.get('size', '10')
+	genre, fromYear, toYear, musicFolderId = map(request.values.get, [ 'genre', 'fromYear', 'toYear', 'musicFolderId' ])
 
 	try:
 		size = int(size) if size else 10
@@ -69,7 +69,7 @@ def rand_songs():
 
 @app.route('/rest/getAlbumList.view', methods = [ 'GET', 'POST' ])
 def album_list():
-	ltype, size, offset = map(request.args.get, [ 'type', 'size', 'offset' ])
+	ltype, size, offset = map(request.values.get, [ 'type', 'size', 'offset' ])
 	try:
 		size = int(size) if size else 10
 		offset = int(offset) if offset else 0
@@ -119,7 +119,7 @@ def album_list():
 
 @app.route('/rest/getAlbumList2.view', methods = [ 'GET', 'POST' ])
 def album_list_id3():
-	ltype, size, offset = map(request.args.get, [ 'type', 'size', 'offset' ])
+	ltype, size, offset = map(request.values.get, [ 'type', 'size', 'offset' ])
 	try:
 		size = int(size) if size else 10
 		offset = int(offset) if offset else 0

--- a/supysonic/api/annotation.py
+++ b/supysonic/api/annotation.py
@@ -30,7 +30,7 @@ from supysonic.db import RatingTrack, RatingFolder
 
 @app.route('/rest/star.view', methods = [ 'GET', 'POST' ])
 def star():
-	id, albumId, artistId = map(request.args.getlist, [ 'id', 'albumId', 'artistId' ])
+	id, albumId, artistId = map(request.values.getlist, [ 'id', 'albumId', 'artistId' ])
 
 	def try_star(ent, starred_ent, eid):
 		try:
@@ -75,7 +75,7 @@ def star():
 
 @app.route('/rest/unstar.view', methods = [ 'GET', 'POST' ])
 def unstar():
-	id, albumId, artistId = map(request.args.getlist, [ 'id', 'albumId', 'artistId' ])
+	id, albumId, artistId = map(request.values.getlist, [ 'id', 'albumId', 'artistId' ])
 
 	def try_unstar(ent, eid):
 		try:
@@ -109,7 +109,7 @@ def unstar():
 
 @app.route('/rest/setRating.view', methods = [ 'GET', 'POST' ])
 def rate():
-	id, rating = map(request.args.get, [ 'id', 'rating' ])
+	id, rating = map(request.values.get, [ 'id', 'rating' ])
 	if not id or not rating:
 		return request.error_formatter(10, 'Missing parameter')
 
@@ -153,7 +153,7 @@ def scrobble():
 	if not status:
 		return res
 
-	t, submission = map(request.args.get, [ 'time', 'submission' ])
+	t, submission = map(request.values.get, [ 'time', 'submission' ])
 
 	if t:
 		try:

--- a/supysonic/api/browse.py
+++ b/supysonic/api/browse.py
@@ -37,8 +37,8 @@ def list_folders():
 
 @app.route('/rest/getIndexes.view', methods = [ 'GET', 'POST' ])
 def list_indexes():
-	musicFolderId = request.args.get('musicFolderId')
-	ifModifiedSince = request.args.get('ifModifiedSince')
+	musicFolderId = request.values.get('musicFolderId')
+	ifModifiedSince = request.values.get('ifModifiedSince')
 	if ifModifiedSince:
 		try:
 			ifModifiedSince = int(ifModifiedSince) / 1000

--- a/supysonic/api/chat.py
+++ b/supysonic/api/chat.py
@@ -24,7 +24,7 @@ from supysonic.db import ChatMessage
 
 @app.route('/rest/getChatMessages.view', methods = [ 'GET', 'POST' ])
 def get_chat():
-	since = request.args.get('since')
+	since = request.values.get('since')
 	try:
 		since = int(since) / 1000 if since else None
 	except:
@@ -38,7 +38,7 @@ def get_chat():
 
 @app.route('/rest/addChatMessage.view', methods = [ 'GET', 'POST' ])
 def add_chat_message():
-	msg = request.args.get('message')
+	msg = request.values.get('message')
 	if not msg:
 		return request.error_formatter(10, 'Missing message')
 

--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -45,7 +45,7 @@ def stream_media():
 	if not status:
 		return res
 
-	maxBitRate, format, timeOffset, size, estimateContentLength, client = map(request.args.get, [ 'maxBitRate', 'format', 'timeOffset', 'size', 'estimateContentLength', 'c' ])
+	maxBitRate, format, timeOffset, size, estimateContentLength, client = map(request.values.get, [ 'maxBitRate', 'format', 'timeOffset', 'size', 'estimateContentLength', 'c' ])
 	if format:
 		format = format.lower()
 
@@ -138,7 +138,7 @@ def cover_art():
 	if not res.has_cover_art or not os.path.isfile(os.path.join(res.path, 'cover.jpg')):
 		return request.error_formatter(70, 'Cover art not found')
 
-	size = request.args.get('size')
+	size = request.values.get('size')
 	if size:
 		try:
 			size = int(size)
@@ -164,7 +164,7 @@ def cover_art():
 
 @app.route('/rest/getLyrics.view', methods = [ 'GET', 'POST' ])
 def lyrics():
-	artist, title = map(request.args.get, [ 'artist', 'title' ])
+	artist, title = map(request.values.get, [ 'artist', 'title' ])
 	if not artist:
 		return request.error_formatter(10, 'Missing artist parameter')
 	if not title:

--- a/supysonic/api/playlists.py
+++ b/supysonic/api/playlists.py
@@ -29,7 +29,7 @@ from . import get_entity
 def list_playlists():
 	query = store.find(Playlist, Or(Playlist.user_id == request.user.id, Playlist.public == True)).order_by(Playlist.name)
 
-	username = request.args.get('username')
+	username = request.values.get('username')
 	if username:
 		if not request.user.admin:
 			return request.error_formatter(50, 'Restricted to admins')
@@ -51,9 +51,9 @@ def show_playlist():
 @app.route('/rest/createPlaylist.view', methods = [ 'GET', 'POST' ])
 def create_playlist():
 	# Only(?) method where the android client uses form data rather than GET params
-	playlist_id, name = map(lambda x: request.args.get(x) or request.form.get(x), [ 'playlistId', 'name' ])
+	playlist_id, name = map(request.values.get, [ 'playlistId', 'name' ])
 	# songId actually doesn't seem to be required
-	songs = request.args.getlist('songId') or request.form.getlist('songId')
+	songs = request.values.getlist('songId')
 	try:
 		playlist_id = uuid.UUID(playlist_id) if playlist_id else None
 		songs = set(map(uuid.UUID, songs))
@@ -112,8 +112,8 @@ def update_playlist():
 		return request.error_formatter(50, "You're not allowed to delete a playlist that isn't yours")
 
 	playlist = res
-	name, comment, public = map(request.args.get, [ 'name', 'comment', 'public' ])
-	to_add, to_remove = map(request.args.getlist, [ 'songIdToAdd', 'songIndexToRemove' ])
+	name, comment, public = map(request.values.get, [ 'name', 'comment', 'public' ])
+	to_add, to_remove = map(request.values.getlist, [ 'songIdToAdd', 'songIndexToRemove' ])
 	try:
 		to_add = set(map(uuid.UUID, to_add))
 		to_remove = sorted(set(map(int, to_remove)))

--- a/supysonic/api/search.py
+++ b/supysonic/api/search.py
@@ -25,7 +25,7 @@ from supysonic.db import Folder, Track, Artist, Album
 
 @app.route('/rest/search.view', methods = [ 'GET', 'POST' ])
 def old_search():
-	artist, album, title, anyf, count, offset, newer_than = map(request.args.get, [ 'artist', 'album', 'title', 'any', 'count', 'offset', 'newerThan' ])
+	artist, album, title, anyf, count, offset, newer_than = map(request.values.get, [ 'artist', 'album', 'title', 'any', 'count', 'offset', 'newerThan' ])
 	try:
 		count = int(count) if count else 20
 		offset = int(offset) if offset else 0
@@ -66,7 +66,7 @@ def old_search():
 @app.route('/rest/search2.view', methods = [ 'GET', 'POST' ])
 def new_search():
 	query, artist_count, artist_offset, album_count, album_offset, song_count, song_offset = map(
-		request.args.get, [ 'query', 'artistCount', 'artistOffset', 'albumCount', 'albumOffset', 'songCount', 'songOffset' ])
+		request.values.get, [ 'query', 'artistCount', 'artistOffset', 'albumCount', 'albumOffset', 'songCount', 'songOffset' ])
 
 	try:
 		artist_count =  int(artist_count)  if artist_count  else 20
@@ -95,7 +95,7 @@ def new_search():
 @app.route('/rest/search3.view', methods = [ 'GET', 'POST' ])
 def search_id3():
 	query, artist_count, artist_offset, album_count, album_offset, song_count, song_offset = map(
-		request.args.get, [ 'query', 'artistCount', 'artistOffset', 'albumCount', 'albumOffset', 'songCount', 'songOffset' ])
+		request.values.get, [ 'query', 'artistCount', 'artistOffset', 'albumCount', 'albumOffset', 'songCount', 'songOffset' ])
 
 	try:
 		artist_count =  int(artist_count)  if artist_count  else 20

--- a/supysonic/api/user.py
+++ b/supysonic/api/user.py
@@ -25,7 +25,7 @@ from supysonic.managers.user import UserManager
 
 @app.route('/rest/getUser.view', methods = [ 'GET', 'POST' ])
 def user_info():
-	username = request.args.get('username')
+	username = request.values.get('username')
 	if username is None:
 		return request.error_formatter(10, 'Missing username')
 
@@ -50,7 +50,7 @@ def user_add():
 	if not request.user.admin:
 		return request.error_formatter(50, 'Admin restricted')
 
-	username, password, email, admin = map(request.args.get, [ 'username', 'password', 'email', 'adminRole' ])
+	username, password, email, admin = map(request.values.get, [ 'username', 'password', 'email', 'adminRole' ])
 	if not username or not password or not email:
 		return request.error_formatter(10, 'Missing parameter')
 	admin = True if admin in (True, 'True', 'true', 1, '1') else False
@@ -66,7 +66,7 @@ def user_del():
 	if not request.user.admin:
 		return request.error_formatter(50, 'Admin restricted')
 
-	username = request.args.get('username')
+	username = request.values.get('username')
 	user = store.find(User, User.name == username).one()
 	if not user:
 		return request.error_formatter(70, 'Unknown user')
@@ -79,7 +79,7 @@ def user_del():
 
 @app.route('/rest/changePassword.view', methods = [ 'GET', 'POST' ])
 def user_changepass():
-	username, password = map(request.args.get, [ 'username', 'password' ])
+	username, password = map(request.values.get, [ 'username', 'password' ])
 	if not username or not password:
 		return request.error_formatter(10, 'Missing parameter')
 


### PR DESCRIPTION
The subsonic API docs do not generally specify whether the GET or POST method should be used. Indeed, `py-sonic` (<a href="https://pypi.python.org/pypi/py-sonic/">pypi</a>, <a href="https://github.com/crustymonkey/py-sonic">git</a>, note that `py-sonic` only supports token-based authentication currently; crustymonkey/py-sonic#17 is a request to add a fallback option to use old auth), which is used, for example, by <a href="https://pypi.python.org/pypi/Mopidy-Subsonic">`mopidy-subsonic`</a> uses POST requests for most of its actions.

This pull makes `supysonic` accept both GET and POST requests in the API.