### PR TITLE
Rescan albums when track metadata changes

### DIFF
--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -154,7 +154,11 @@ class Scanner:
 		tr.genre    = self.__try_read_tag(tag, 'genre')
 		tr.duration = int(tag.info.length)
 		if not add:
-			tr.album = self.__find_album(self.__try_read_tag(tag, 'artist', ''), self.__try_read_tag(tag, 'album', ''))
+			old_album = tr.album
+			new_album = self.__find_album(self.__try_read_tag(tag, 'artist', ''), self.__try_read_tag(tag, 'album', ''))
+			if old_album.id != new_album.id:
+				tr.album = new_album
+				self.__albums_to_check.add(old_album)
 		tr.bitrate  = (tag.info.bitrate if hasattr(tag.info, 'bitrate') else int(os.path.getsize(path) * 8 / tag.info.length)) / 1000
 		tr.content_type = get_mime(os.path.splitext(path)[1][1:])
 		tr.last_modification = os.path.getmtime(path)


### PR DESCRIPTION
This enables supysonic to remove unused albums (and therefore artists) when the metadata of an existing track is modified and there are no longer any more tracks tagged with the album.