### PR TITLE
use range requests when available

### DIFF
--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -119,7 +119,7 @@ def stream_media():
 		app.logger.info('Transcoding track {0.id} for user {1.id}. Source: {2} at {0.bitrate}kbps. Dest: {3} at {4}kbps'.format(res, request.user, src_suffix, dst_suffix, dst_bitrate))
 		response = Response(transcode(), mimetype = dst_mimetype)
 	else:
-		response = send_file(res.path, mimetype = dst_mimetype)
+		response = send_file(res.path, mimetype = dst_mimetype, conditional=True)
 
 	res.play_count = res.play_count + 1
 	res.last_play = now()
@@ -135,7 +135,7 @@ def download_media():
 	if not status:
 		return res
 
-	return send_file(res.path)
+	return send_file(res.path, conditional=True)
 
 @app.route('/rest/getCoverArt.view', methods = [ 'GET', 'POST' ])
 def cover_art():


### PR DESCRIPTION
This pull adds the ability to use range requests in `send_file` when streaming or downloading original files; see https://github.com/pallets/flask/blob/3fc8be5a4e9c1db58dcc74d3d48bf70b6a8db932/flask/helpers.py#L586.

Once werkzeug v0.12 is released, with G-d's help, this will start supporting range requests.

See also <a href="https://github.com/pallets/werkzeug/blob/master/CHANGES">werkzeug changelog</a>.