### PR TITLE
Allow accessing public playlists via API when not admin

### DIFF
--- a/supysonic/api/playlists.py
+++ b/supysonic/api/playlists.py
@@ -37,7 +37,7 @@ def list_playlists():
 @api.route('/getPlaylist.view', methods = [ 'GET', 'POST' ])
 def show_playlist():
     res = get_entity(Playlist)
-    if res.user.id != request.user.id and not request.user.admin:
+    if res.user.id != request.user.id and not res.public and not request.user.admin:
         raise Forbidden()
 
     info = res.as_subsonic_playlist(request.user)


### PR DESCRIPTION
This allows public playlist contents to be accessed  even when not an admin. Previously they would show up in the list of playlists, but would not allow access to the playlist itself.

Thanks for the wonderful project! :-)