### PR TITLE
Several hacks.

### DIFF
--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -107,7 +107,7 @@ class Folder(PathMixin, db.Entity):
             not exists(f for f in Folder if f.parent == self) and not self.root)
         total = 0
         while True:
-            count = query.delete(bulk = True)
+            count = query.delete(bulk = False)
             total += count
             if not count:
                 return total
@@ -140,7 +140,7 @@ class Artist(db.Entity):
     @classmethod
     def prune(cls):
         return cls.select(lambda self: not exists(a for a in Album if a.artist == self) and \
-            not exists(t for t in Track if t.artist == self)).delete(bulk = True)
+            not exists(t for t in Track if t.artist == self)).delete(bulk = False)
 
 class Album(db.Entity):
     _table_ = 'album'
@@ -180,7 +180,7 @@ class Album(db.Entity):
 
     @classmethod
     def prune(cls):
-        return cls.select(lambda self: not exists(t for t in Track if t.album == self)).delete(bulk = True)
+        return cls.select(lambda self: not exists(t for t in Track if t.album == self)).delete(bulk = False)
 
 class Track(PathMixin, db.Entity):
     _table_ = 'track'

--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -133,7 +133,7 @@ class Scanner:
 
         trdict['disc']     = self.__try_read_tag(tag, 'discnumber',  1, lambda x: int(x[0].split('/')[0]))
         trdict['number']   = self.__try_read_tag(tag, 'tracknumber', 1, lambda x: int(x[0].split('/')[0]))
-        trdict['title']    = self.__try_read_tag(tag, 'title', '')
+        trdict['title']    = self.__try_read_tag(tag, 'title', '???')
         trdict['year']     = self.__try_read_tag(tag, 'date', None, lambda x: int(x[0].split('-')[0]))
         trdict['genre']    = self.__try_read_tag(tag, 'genre')
         trdict['duration'] = int(tag.info.length)

--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -124,12 +124,14 @@ class Scanner:
 
             trdict = { 'path': path }
 
-        artist = self.__try_read_tag(tag, 'artist')
-        if not artist:
+        artist = self.__try_read_tag(tag, 'artist', '')
+        if artist.strip() == '':
             return
 
         album       = self.__try_read_tag(tag, 'album', '[non-album tracks]')
         albumartist = self.__try_read_tag(tag, 'albumartist', artist)
+        if albumartist.strip() == '':
+            albumartist = artist
 
         trdict['disc']     = self.__try_read_tag(tag, 'discnumber',  1, lambda x: int(x[0].split('/')[0]))
         trdict['number']   = self.__try_read_tag(tag, 'tracknumber', 1, lambda x: int(x[0].split('/')[0]))


### PR DESCRIPTION
An empty 'title' string throws "ValueError: Attribute Track.title is required" with MySQL and MariaDB backends. The schema seems fine, but I guess Pony passes a Null rather than an empty string?

Whatever the actual cause, this hack covers it up enough for my purposes. I imagine you'd want to actually fix it in the development version, but I figured a crappy PR is better than a cryptic bug report.