### PR TITLE
Fix crash when looking for cover art in a directory that doesn't exist

### DIFF
--- a/supysonic/covers.py
+++ b/supysonic/covers.py
@@ -59,6 +59,9 @@ def is_valid_cover(path):
         return False
 
 def find_cover_in_folder(path, album_name = None):
+    if not os.path.exists(path):
+        return None
+
     if not os.path.isdir(path):
         raise ValueError('Invalid path')
 


### PR DESCRIPTION
This can happen when deleting an album and performing a re-scan

Traceback for reference:
```
Traceback (most recent call last):
  File "/[redacted]/venv/bin/supysonic-cli", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/[redacted]/supysonic/bin/supysonic-cli", line 23, in <module>
    cli.onecmd(' '.join(sys.argv[1:]))
  File "<string>", line 2, in onecmd
  File "/[redacted]/venv/lib/python3.6/site-packages/pony/orm/core.py", line 460, in new_func
    try: return func(*args, **kwargs)
  File "/usr/lib64/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "/[redacted]/supysonic/supysonic/cli.py", line 67, in method
    return func(** { key: vars(args)[key] for key in vars(args) if key != 'action' })
  File "/[redacted]/supysonic/supysonic/cli.py", line 175, in folder_scan
    scanner.scan(folder, TimedProgressDisplay(folder.name, self.stdout))
  File "/[redacted]/supysonic/supysonic/scanner.py", line 94, in scan
    cover = find_cover_in_folder(f.path, album_name)
  File "/[redacted]/supysonic/supysonic/covers.py", line 63, in find_cover_in_folder
    raise ValueError('Invalid path')
ValueError: Invalid path
```