### PR TITLE
Ensure that Exceptions are stringified before being returned

### DIFF
--- a/supysonic/api/errors.py
+++ b/supysonic/api/errors.py
@@ -18,7 +18,7 @@ from .exceptions import GenericError, MissingParameter, NotFound, ServerError
 @api.errorhandler(ValueError)
 def value_error(e):
     rollback()
-    return GenericError(e)
+    return GenericError("{0.__class__.__name__}: {0}".format(e))
 
 @api.errorhandler(BadRequestKeyError)
 def key_error(e):
@@ -33,7 +33,7 @@ def not_found(e):
 @api.errorhandler(500)
 def generic_error(e): # pragma: nocover
     rollback()
-    return ServerError(e)
+    return ServerError("{0.__class__.__name__}: {0}".format(e))
 
 #@api.errorhandler(404)
 @api.route('/<path:invalid>', methods = [ 'GET', 'POST' ]) # blueprint 404 workaround


### PR DESCRIPTION
This prevents a `TypeError` from being raised when attempting to serialize an `Exception` to a JSON object.

Note that this doesn't fix the root cause of the issue (which I haven't been able to track down yet). However, if a `SubsonicAPIException` is raised with the an `Exception` object being set as the `message`, the logical thing to do is to stringify that message before returning it to the client (even though it probably shouldn't ever happen). At least then the client will have some record of what went wrong.

Exception for reference:
```
Exception on /rest/getCoverArt.view [GET]
Traceback (most recent call last):
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/app.py", line 1615, in full_dispatch_request
    return self.finalize_request(rv)
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/app.py", line 1630, in finalize_request
    response = self.make_response(rv)
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/app.py", line 1740, in make_response
    rv = self.response_class.force_type(rv, request.environ)
  File "/home/supysonic/venv/lib/python3.6/site-packages/werkzeug/wrappers.py", line 921, in force_type
    response = BaseResponse(*_run_wsgi_app(response, environ))
  File "/home/supysonic/venv/lib/python3.6/site-packages/werkzeug/test.py", line 923, in run_wsgi_app
    app_rv = app(environ, start_response)
  File "/home/supysonic/venv/lib/python3.6/site-packages/werkzeug/exceptions.py", line 155, in __call__
    response = self.get_response(environ)
  File "/home/supysonic/supysonic/supysonic/api/exceptions.py", line 19, in get_response
    rv = request.formatter.error(self.api_code, self.message)
  File "/home/supysonic/supysonic/supysonic/api/formatters.py", line 22, in make_error
    return self.make_response('error', dict(code = code, message = message))
  File "/home/supysonic/supysonic/supysonic/api/formatters.py", line 68, in make_response
    rv = jsonify(self._subsonicify(elem, data))
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/json.py", line 263, in jsonify
    (dumps(data, indent=indent, separators=separators), '\n'),
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/json.py", line 123, in dumps
    rv = _json.dumps(obj, **kwargs)
  File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/lib64/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/lib64/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/home/supysonic/venv/lib/python3.6/site-packages/flask/json.py", line 80, in default
    return _json.JSONEncoder.default(self, o)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'ValueError' is not JSON serializable
```