### PR TITLE
Kill transcoding processes on error

### DIFF
--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -102,8 +102,8 @@ def stream_media():
                     yield data
             except: # pragma: nocover
                 if dec_proc != None:
-                    dec_proc.terminate()
-                proc.terminate()
+                    dec_proc.kill()
+                proc.kill()
 
             if dec_proc != None:
                 dec_proc.wait()


### PR DESCRIPTION
Asking nicely with a SIGTERM doesn't cause the transcoding process(es)
to exit. Using SIGKILL gets the job done.

This was verified by manually sending SIGTERM and SIGKILL signals to
hung transcoding processes, as well as getting a client to abort stream
requests before they had completed.

Fixes #55