### PR TITLE
Add a timeout when fetching remote resources

### DIFF
--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -201,7 +201,7 @@ def lyrics():
 
     try:
         r = requests.get("http://api.chartlyrics.com/apiv1.asmx/SearchLyricDirect",
-            params = { 'artist': artist, 'song': title })
+            params = { 'artist': artist, 'song': title }, timeout = 5)
         root = ElementTree.fromstring(r.content)
 
         ns = { 'cl': 'http://api.chartlyrics.com/' }

--- a/supysonic/lastfm.py
+++ b/supysonic/lastfm.py
@@ -77,9 +77,9 @@ class LastFm:
 
         try:
             if write:
-                r = requests.post('http://ws.audioscrobbler.com/2.0/', data = kwargs)
+                r = requests.post('http://ws.audioscrobbler.com/2.0/', data = kwargs, timeout = 5)
             else:
-                r = requests.get('http://ws.audioscrobbler.com/2.0/', params = kwargs)
+                r = requests.get('http://ws.audioscrobbler.com/2.0/', params = kwargs, timeout = 5)
         except requests.exceptions.RequestException as e:
             self.__logger.warning('Error while connecting to LastFM: ' + str(e))
             return None


### PR DESCRIPTION
Currently, if a remote api like chartlyrics or last.fm is not responding, supysonic will hang for a pretty long time, and will leave the client hanging for longer.  Adding a timeout ensures that this error is quickly reported and handled.

As of me posting this, chartlyrics.com is currently down, hence why tests are failing.  This doesn't fix that, but it at least makes the problem a little more obvious and moves on with the tests, and allows production servers to respond healthily to the missing api.