### PR TITLE
Mock connections to the chartlyrics api while testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         zip_safe=False,
         include_package_data=True,
         test_suite='tests.suite',
-        tests_require = [ 'lxml' ] + [ r for er in extras.values() for r in er ],
+        tests_require = [ 'lxml', 'responses' ] + [ r for er in extras.values() for r in er ],
         classifiers=[
             'Development Status :: 3 - Alpha',
             'Environment :: Console',


### PR DESCRIPTION
Use the responses library to mock connections to the chartlyrics api during tests.  This prevents extraneous requests from being sent during testing, and ensures if the chartlyrics api is down, or tests must be run offline, tests still accurately reflect the state of the program.

Possible caveats:
 - Adds another library for testing
 
   I used the `responses` library in order to handle mocking requests, but this does add another dependency, albeit just for testing.  It is possible to do this using pure python, and I'd be happy to substitute, but I figured I'd run this way past you first.
 - Responds with an error to missing tracks

   I don't have the chartlyrics api in front of me at the minute, since their site is down and I couldn't find another reference, so when a request is made for a song that doesn't exist, like on line 169, I respond with an error.  This does raise a warning in the console, but responding with blank fields causes an error when supysonic tries to format them into a response.  I'm pretty sure that isn't right, but I couldn't figure out what the appropriate response should be for this, and was hoping you could advise.