### PR TITLE
WIP: preliminary git-annex support

### DIFF
--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -65,11 +65,9 @@ class Scanner:
                     continue
 
                 full_path = os.path.join(path, f)
-                if os.path.islink(full_path):
-                    continue
-                elif os.path.isdir(full_path):
+                if os.path.isdir(full_path) and not f.startswith('.'):
                     to_scan.append(full_path)
-                elif os.path.isfile(full_path) and self.__is_valid_path(full_path):
+                elif (os.path.islink(full_path) or os.path.isfile(full_path)) and self.__is_valid_path(full_path):
                     self.scan_file(full_path)
                     scanned += 1
 


### PR DESCRIPTION
Supysonic doesn't deal well with [git-annex][] (GA)
repositories. Because GA stores files as symlinks to an object storage
in `.git/annex/objects`, all the normal `Artist/Album/File.mp3` files
are ignored and instead the actual files in `.git` are parsed.

 [git-annex]: https://git-annex.branchable.com/

Those files have funky filenames based on the file hash, for example:

```
.git/annex/objects/xm/zw/SHA256E-s1093632--6dc57e45ba7f81ed48ab6e581335bd2fb6271e40934c97931c6684cea3eec0b9.mp3/SHA256E-s1093632--6dc57e45ba7f81ed48ab6e581335bd2fb6271e40934c97931c6684cea3eec0b9.mp3
```

This makes most Supysonic client show the garbled filename instead of
the song title and breaks most album grouping behavior.

This patch makes the scanner follows symlinks when scanning and
ignores hidden directories (so `.git`). It's a WIP for now because
ideally the parser would be rewritten to use the faster `os.walk` and
support arbitrary ignore patterns or enable the user to configure
whether symlinks must be followed (see also #144).

But I've been using this patch on my side and it works sufficiently
well.