### PR TITLE
don't require scandir for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ reqs = [
     "Pillow",
     "requests>=1.0.0",
     "mutagen>=1.33",
-    "scandir<2.0.0",
+    "scandir<2.0.0; python_version <= '2.7'",
     "watchdog>=0.8.0",
     "zipstream",
 ]

--- a/supysonic/py23.py
+++ b/supysonic/py23.py
@@ -10,9 +10,9 @@
 
 # Try built-in scandir, fall back to the package for Python 2.7
 try:
-    from os import scandir, DirEntry
+    from os import scandir
 except ImportError:
-    from scandir import scandir, DirEntry
+    from scandir import scandir
 
 # os.replace was added in Python 3.3, provide a fallback for Python 2.7
 try:

--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -20,7 +20,7 @@ from .covers import find_cover_in_folder, has_embedded_cover, CoverFile
 from .db import Folder, Artist, Album, Track, User
 from .db import StarredFolder, StarredArtist, StarredAlbum, StarredTrack
 from .db import RatingFolder, RatingTrack
-from .py23 import scandir, strtype, DirEntry, Queue, QueueEmpty
+from .py23 import scandir, strtype, Queue, QueueEmpty
 
 
 logger = logging.getLogger(__name__)
@@ -194,16 +194,7 @@ class Scanner(Thread):
 
     @db_session
     def scan_file(self, path_or_direntry):
-        if not isinstance(path_or_direntry, (strtype, DirEntry)):
-            raise TypeError(
-                "Expecting string or DirEntry, got " + str(type(path_or_direntry))
-            )
-
-        if isinstance(path_or_direntry, DirEntry):
-            path = path_or_direntry.path
-            basename = path_or_direntry.name
-            stat = path_or_direntry.stat()
-        else:
+        if isinstance(path_or_direntry, strtype):
             path = path_or_direntry
 
             if not os.path.exists(path):
@@ -211,6 +202,10 @@ class Scanner(Thread):
 
             basename = os.path.basename(path)
             stat = os.stat(path)
+        else:
+            path = path_or_direntry.path
+            basename = path_or_direntry.name
+            stat = path_or_direntry.stat()
 
         mtime = int(stat.st_mtime)
         size = stat.st_size

--- a/tests/base/test_scanner.py
+++ b/tests/base/test_scanner.py
@@ -72,10 +72,6 @@ class ScannerTestCase(unittest.TestCase):
 
     @db_session
     def test_scan_file(self):
-        track = db.Track.select().first()
-        self.assertRaises(TypeError, self.scanner.scan_file, None)
-        self.assertRaises(TypeError, self.scanner.scan_file, track)
-
         self.scanner.scan_file("/some/inexistent/path")
         commit()
         self.assertEqual(db.Track.select().count(), 1)


### PR DESCRIPTION
While trying to run the test suite with python3, it kept crashing because `scandir` is missing. `scandir` is a python2 only dependency (since it's been merged in `os` in python3) so this PR marks it as so in `setup.py`.

```
running test
Searching for scandir<2.0.0

Note: Bypassing https://pypi.org/simple/scandir/ (disallowed host; see http://bit.ly/2hrImnY for details).

Couldn't find index page for 'scandir' (maybe misspelled?)
Scanning index of all packages (this may take a while)

Note: Bypassing https://pypi.org/simple/ (disallowed host; see http://bit.ly/2hrImnY for details).

No local packages or working download links found for scandir<2.0.0
error: Could not find suitable distribution for Requirement.parse('scandir<2.0.0')
E: pybuild pybuild:341: test: plugin distutils failed with: exit code=1: python3.7 setup.py test 
dh_auto_test: pybuild --test -i python{version} -p 3.7 returned exit code 13
make: *** [debian/rules:6: build] Error 25
```