### PR TITLE
WIP: add a rudimentary functional test to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,24 @@ python:
   - 3.5
   - 3.6
   - 3.7
+before_install:
+  - sudo apt-get install -y sqlite flac
+addons:
+  apt:
+    update: true
 install:
   - pip install -r travis-requirements.txt
 script:
   - coverage run setup.py test
   - coverage run -a setup.py test --test-suite tests.with_net
+  - mkdir Music
+  - flac /dev/null --endian=big --channels=2 --bps=16 --sample-rate=5 --sign=unsigned --silent -o "Music/blank.flac"
+  - metaflac --set-tag="TITLE=Foo" --set-tag="ARTIST=The Foos" --set-tag="ALBUM=Bar 2000" --set-tag="GENRE=Electronic" Music/blank.flac
+  - sqlite supysonic.db ""
+  - mkdir /tmp/supysonic
+  - cp supysonic.db /tmp/supysonic/
+  - supysonic-cli user add MyUserName -a -p MyAwesomePassword
+  - supysonic-cli folder add MyLibrary Music
+  - supysonic-cli folder scan MyLibrary 2>&1
+
 after_script: codecov


### PR DESCRIPTION
While working on the Debian package, I saw that there were no functional tests for supysonic, only unit tests.

[I wrote a basic functional test][integration] for the Debian package`autopkgtest` feature and thought I would contribute it back upstream. I'm not sure putting commands one after the other in Travis like I did is very elegant though.

A couple of questions:

* do you want me to create a directory called `tests/functional` and push shell scripts there ?
* is using shell scripts for that OK with you? I've never really done functional tests with a Python test framework as I feel Shell Scripts are well suited for that, but I'd be happy to use one if you point me in the right direction.
* is there a way to use codecov for these kind of tests? I don't think I've ever seen that, but maybe you know better.

At the moment this is still very basic and not very systematic, but if we can agree on a functional test structure to work on, I'd be happy to work on this.

[integration]: https://salsa.debian.org/python-team/applications/supysonic/commit/2e871cf858e6ba9da5454d8b663a0304ed872adf