### PR TITLE
remove support for IE8-9

### DIFF
--- a/supysonic/templates/layout.html
+++ b/supysonic/templates/layout.html
@@ -20,12 +20,6 @@
     <link href="{{ url_for('static', filename='css/bootstrap-theme.min.css') }}" rel="stylesheet">
     <link href="{{ url_for('static', filename='css/supysonic.css') }}" rel="stylesheet">
 
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
   </head>
   <body>
     <nav class="navbar navbar-default navbar-fixed-top">


### PR DESCRIPTION
Hello!

This PR removes support for IE8 and IE9. That code was causing me problems for the Debian packaging, since respond.js isn't packaged in Debian and I can't add embedded copies of external libraries.

It's not critical (I could patch that code out in Debian), but I feel it's OK to deprecate IE8 an IE9 support. IE9 supports `@media` calls and IE10 supports HTML5, so from IE10 or greater the current code is fine.