### PR TITLE
Make sure all messages are printed on a new line

### DIFF
--- a/supysonic/cli.py
+++ b/supysonic/cli.py
@@ -278,7 +278,7 @@ class SupysonicCLI(cmd.Cmd):
         scanner.run()
         stats = scanner.stats()
 
-        self.write_line("Scanning done")
+        self.write_line("\nScanning done")
         self.write_line(
             "Added: {0.artists} artists, {0.albums} albums, {0.tracks} tracks".format(
                 stats.added


### PR DESCRIPTION
Without the patch:

```
foo@bar:/home/foo# supysonic-cli folder scan Musique
Couldn't connect to the daemon, scanning in foreground
Scanning 'Musique': 11407 files scannedScanning done
Added: 0 artists, 0 albums, 0 tracks
Deleted: 0 artists, 0 albums, 0 tracks
```

With the patch:

```
foo@bar:/home/foo# supysonic-cli folder scan Musique
Couldn't connect to the daemon, scanning in foreground
Scanning 'Musique': 11453 files scanned
Scanning done
Added: 0 artists, 0 albums, 0 tracks
Deleted: 0 artists, 0 albums, 0 tracks
```