### PR TITLE
Add default_transcode_target option

### DIFF
--- a/docs/transcoding.md
+++ b/docs/transcoding.md
@@ -28,6 +28,7 @@ All these are defined by the following variables:
 * `trancoder`
 * `decoder`
 * `encoder`
+* `default_transcode_target`
 
 where `EXT` is the lowercase file extension of the matching audio format.
 `transcoder`s variables have two extensions: the first one is the source
@@ -61,6 +62,9 @@ One final note: the original file should be provided as an argument of
 transcoders and decoders. All transcoders, decoders and encoders should write
 to standard output, and encoders should read from standard input.
 
+The value of `default_transcode_target` will be used as output format when a
+client requests a bitrate lower than the original file and no specific format.
+
 ## Suggested configuration
 
 Here are some example configuration that you could use. This is provided as-is,
@@ -75,5 +79,6 @@ decoder_ogg = oggdec -o %srcpath
 decoder_flac = flac -d -c -s %srcpath
 encoder_mp3 = lame --quiet -b %outrate - -
 encoder_ogg = oggenc2 -q -M %outrate -
+default_transcode_target = mp3
 ```
 

--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -83,6 +83,8 @@ def stream_media():
     dst_bitrate = res.bitrate
     dst_mimetype = res.mimetype
 
+    config = current_app.config["TRANSCODING"]
+
     prefs = request.client
     if prefs.format:
         dst_suffix = prefs.format
@@ -94,6 +96,8 @@ def stream_media():
 
         if dst_bitrate > maxBitRate and maxBitRate != 0:
             dst_bitrate = maxBitRate
+            if not format:
+                format = config.get("default_transcode_target")
 
     if format and format != "raw" and format != src_suffix:
         dst_suffix = format
@@ -112,7 +116,6 @@ def stream_media():
                 cache.get(cache_key), mimetype=dst_mimetype, conditional=True
             )
         except CacheMiss:
-            config = current_app.config["TRANSCODING"]
             transcoder = config.get("transcoder_{}_{}".format(src_suffix, dst_suffix))
             decoder = config.get("decoder_" + src_suffix) or config.get("decoder")
             encoder = config.get("encoder_" + dst_suffix) or config.get("encoder")


### PR DESCRIPTION
Add a `default_transcode_target` option to the `transcoding` section of the config.
The value of this option will be used as target format when a client requests a bitrate lower than the original file with no target format.

I found that DSub was eating my mobile data when streaming flac files, even though it is configured to limit bitrate to 256k on mobile. Turns out that in this configuration, DSub only requests a bitrate without any target format. As a result, the whole flac file was returned.