### PR TITLE
Support setting basic metadata in transcoded media

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Supysonic_ currently targets the version 1.9.0 of the _Subsonic_ API. For more
 details, go check the [API implementation status][docs-api].
 
 [subsonic]: http://www.subsonic.org/
-[transcoding]: docs/trancoding.md
+[transcoding]: docs/transcoding.md
 [lastfm]: https://last.fm/
 [docs-api]: docs/api.md
 

--- a/config.sample
+++ b/config.sample
@@ -64,7 +64,7 @@ decoder_mp3 = mpg123 --quiet -w - %srcpath
 decoder_ogg = oggdec -o %srcpath
 decoder_flac = flac -d -c -s %srcpath
 encoder_mp3 = lame --quiet -b %outrate - -
-encoder_ogg = oggenc2 -q -M %outrate -
+encoder_ogg = oggenc2 -Q -M %outrate -
 
 ; Default format, used when a client requests a bitrate lower than the original
 ; file and no specific format

--- a/docs/transcoding.md
+++ b/docs/transcoding.md
@@ -57,6 +57,14 @@ program. The command-lines can include the following fields:
 * `%srcfmt`: extension of the original file
 * `%outfmt`: extension of the resulting file
 * `%outrate`: bitrate of the resulting file
+* `%title`: title of the file to transcode
+* `%album`: album name of the file to transcode
+* `%artist`: artist name of the file to transcode
+* `%tracknumber`: track number of the file to transcode
+* `%totaltracks`: number of tracks in the album of the file to transcode
+* `%discnumber`: disc number of the file to transcode
+* `%genre`: genre of the file to transcode (not always available, defaults to "")
+* `%year`: year of the file to transcode (not always available, defaults to "")
 
 One final note: the original file should be provided as an argument of
 transcoders and decoders. All transcoders, decoders and encoders should write
@@ -67,9 +75,10 @@ client requests a bitrate lower than the original file and no specific format.
 
 ## Suggested configuration
 
-Here are some example configuration that you could use. This is provided as-is,
+Here is an example configuration that you could use. This is provided as-is,
 and some configurations haven't been tested.
 
+Basic configuration:
 ```ini
 [transcoding]
 transcoder_mp3_mp3 = lame --quiet --mp3input -b %outrate %srcpath -
@@ -78,7 +87,19 @@ decoder_mp3 = mpg123 --quiet -w - %srcpath
 decoder_ogg = oggdec -o %srcpath
 decoder_flac = flac -d -c -s %srcpath
 encoder_mp3 = lame --quiet -b %outrate - -
-encoder_ogg = oggenc2 -q -M %outrate -
+encoder_ogg = oggenc2 -Q -M %outrate -
 default_transcode_target = mp3
 ```
 
+To include track metadata in the transcoded stream:
+```ini
+[transcoding]
+transcoder_mp3_mp3 = lame --quiet --mp3input -b %outrate --tt %title --tl %album --ta %artist --tn %tracknumber/%totaltracks --tv TPOS=%discnumber --tg %genre --ty %year --add-id3v2 %srcpath -
+transcoder = ffmpeg -i %srcpath -ab %outratek -v 0 -metadata title=%title -metadata album=%album -metadata author=%artist -metadata track=%tracknumber/%totaltracks -metadata disc=%discnumber -metadata genre=%genre -metadata date=%year -f %outfmt -
+decoder_mp3 = mpg123 --quiet -w - %srcpath
+decoder_ogg = oggdec -o %srcpath
+decoder_flac = flac -d -c -s %srcpath
+encoder_mp3 = lame --quiet -b %outrate --tt %title --tl %album --ta %artist --tn %tracknumber/%totaltracks --tv TPOS=%discnumber --tg %genre --ty %year --add-id3v2 - -
+encoder_ogg = oggenc2 -Q -M %outrate -t %title -l %album -a %artist -N %tracknumber -c TOTALTRACKS=%totaltracks -c DISCNUMBER=%discnumber -G %genre -d %year -
+default_transcode_target = mp3
+```


### PR DESCRIPTION
I didn't change the transcode settings in `config.sample` to ones that add metadata but can if you think that adding the metadata is a reasonable default.

Other small fixes:
 - Fixed typo in README
 - Fixed `oggenc2` using `-q` instead of `-Q` to mean "quiet"

Fixes #170