### PR TITLE
fix SyntaxWarnings

### DIFF
--- a/supysonic/api/formatters.py
+++ b/supysonic/api/formatters.py
@@ -59,7 +59,7 @@ class JSONBaseFormatter(BaseFormatter):
         if (elem is None) != (data is None):
             raise ValueError("Expecting both elem and data or neither of them")
 
-        rv = {"status": "failed" if elem is "error" else "ok", "version": API_VERSION}
+        rv = {"status": "failed" if elem == "error" else "ok", "version": API_VERSION}
         if data:
             rv[elem] = self.__remove_empty_lists(data)
 
@@ -135,7 +135,7 @@ class XMLFormatter(BaseFormatter):
             raise ValueError("Expecting both elem and data or neither of them")
 
         response = {
-            "status": "failed" if elem is "error" else "ok",
+            "status": "failed" if elem == "error" else "ok",
             "version": API_VERSION,
             "xmlns": "http://subsonic.org/restapi",
         }


### PR DESCRIPTION
Fix two minor `SyntaxWarning` uncovered by running the testsuite with python3.8 

```
/builds/python-team/applications/supysonic/debian/output/supysonic-0.4.1/supysonic/api/formatters.py:63: SyntaxWarning: "is" with a literal. Did you mean "=="?
  rv = {"status": "failed" if elem is "error" else "ok", "version": API_VERSION}
/builds/python-team/applications/supysonic/debian/output/supysonic-0.4.1/supysonic/api/formatters.py:139: SyntaxWarning: "is" with a literal. Did you mean "=="?
  "status": "failed" if elem is "error" else "ok",
```