### PR TITLE
add unit for configuration option `wait_delay`

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -43,7 +43,7 @@ run_watcher = yes
 
 ; Delay before triggering scanning operation after a change have been detected
 ; This prevents running too many scans when multiple changes are detected for a
-; single file over a short time span. Default: 5
+; single file over a short time span. Default: 5 seconds
 wait_delay = 5
 
 ; Command used by the jukebox

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,7 @@ run_watcher = yes
 
 ; Delay before triggering scanning operation after a change have been detected
 ; This prevents running too many scans when multiple changes are detected for a
-; single file over a short time span. Default: 5
+; single file over a short time span. Default: 5 seconds
 wait_delay = 5
 
 ; Command used by the jukebox


### PR DESCRIPTION
Add the unit seconds to the configuration  option `wait_delay` to the example config.

Closes #177 