### PR TITLE
Implement dummy method to getVideos.view

### DIFF
--- a/supysonic/api/__init__.py
+++ b/supysonic/api/__init__.py
@@ -117,4 +117,5 @@ from .search import *
 from .playlists import *
 from .jukebox import *
 from .radio import *
+from .videos import *
 from .unsupported import *

--- a/supysonic/api/unsupported.py
+++ b/supysonic/api/unsupported.py
@@ -11,7 +11,6 @@ from . import api
 from .exceptions import GenericError
 
 methods = (
-    "getVideos",
     "getAvatar",
     "getShares",
     "createShare",

--- a/supysonic/api/videos.py
+++ b/supysonic/api/videos.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2020 Óscar García Amor <ogarcia@connectical.com>
+#
+# Distributed under terms of the GNU GPLv3 license.
+
+from flask import request
+
+from . import api
+
+@api.route("/getVideos.view", methods=["GET", "POST"])
+def get_videos():
+    return request.formatter(
+            "videos",
+            dict(video=[])
+    )


### PR DESCRIPTION
Supysonic targets the version API 1.9.0 that supports getVideos.view, is better return an empty list that a not supported message because some clients won't understand it.

Feel free to change copyright in `videos.py`. Is my template system that add these header to new files :smile: 