### PR TITLE
Fix exception handling

### DIFF
--- a/supysonic/api/__init__.py
+++ b/supysonic/api/__init__.py
@@ -41,7 +41,7 @@ def decode_password(password):
 
     try:
         return binascii.unhexlify(password[4:].encode("utf-8")).decode("utf-8")
-    except:
+    except ValueError:
         return password
 
 

--- a/supysonic/api/media.py
+++ b/supysonic/api/media.py
@@ -164,7 +164,8 @@ def stream_media():
                         if not data:
                             break
                         yield data
-                except:  # pragma: nocover
+                except BaseException:
+                    # Make sure child processes are always killed
                     if dec_proc != None:
                         dec_proc.kill()
                     proc.kill()

--- a/supysonic/cache.py
+++ b/supysonic/cache.py
@@ -159,9 +159,10 @@ class Cache(object):
                     self._make_space(size, key=key)
                 os.replace(f.name, self._filepath(key))
                 self._record_file(key, size)
-        except:
+        except Exception:
             f.close()
-            os.remove(f.name)
+            with contextlib.suppress(OSError):
+                os.remove(f.name)
             raise
 
     def set(self, key, value):

--- a/supysonic/jukebox.py
+++ b/supysonic/jukebox.py
@@ -157,6 +157,6 @@ class Jukebox(object):
         logger.debug("Start playing with command %s", args)
         try:
             return Popen(args, stdin=DEVNULL, stdout=DEVNULL, stderr=DEVNULL)
-        except:
-            logger.exception("Failed running play command")
+        except Exception:
+            logger.exception("Failed to run play command")
             return None

--- a/supysonic/schema/migration/postgres/20180317.py
+++ b/supysonic/schema/migration/postgres/20180317.py
@@ -5,7 +5,7 @@ import uuid
 
 try:
     bytes = buffer
-except:
+except NameError:
     pass
 
 parser = argparse.ArgumentParser()

--- a/supysonic/schema/migration/sqlite/20180317.py
+++ b/supysonic/schema/migration/sqlite/20180317.py
@@ -5,7 +5,7 @@ import uuid
 
 try:
     bytes = buffer
-except:
+except NameError:
     pass
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Bare excepts will catch `GeneratorExit` exceptions which are raised whenever a generator stops. This was causing issues when transcoding and caching the results.

All instances of bare excepts have been replaced with scoped versions.