### PR TITLE
Update config.py

### DIFF
--- a/supysonic/config.py
+++ b/supysonic/config.py
@@ -58,10 +58,10 @@ class DefaultConfig:
 
 class IniConfig(DefaultConfig):
     common_paths = [
-        "/etc/supysonic",
+        "/etc/supysonic/supysonic.conf",
         os.path.expanduser("~/.supysonic"),
         os.path.expanduser("~/.config/supysonic/supysonic.conf"),
-        "supysonic.conf",
+        "/etc/supysonic.conf"
     ]
 
     def __init__(self, paths):


### PR DESCRIPTION
The way the config detection was written before, I could only get supysonic working by renaming my /etc/supysonic/supysonic.conf to /etc/supysonic, which doesn't make sense and I don't think that's what you meant to do. With this change, either /etc/supysonic.conf or /etc/supysonic/supysonic.conf will be detected and loaded.