### PR TITLE
Include man pages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,10 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Topic :: Multimedia :: Sound/Audio",
     ],
+    data_files = [('man/man1', [
+        'docs/_build/man/supysonic-cli.1',
+        'docs/_build/man/supysonic-cli-user.1',
+        'docs/_build/man/supysonic-cli-folder.1',
+        'docs/_build/man/supysonic-daemon.1',
+        ])],
 )


### PR DESCRIPTION
After generating the man pages with `make man` from docs folder this change includes them in the Python package, making it easier to package supysonic