### PR TITLE
merge identical genre tags in album info

### DIFF
--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -240,7 +240,7 @@ class Album(db.Entity):
         if count(self.tracks.year) > 0:
             info["year"] = min(self.tracks.year)
 
-        genre = ", ".join(self.tracks.genre)
+        genre = ", ".join(list(set(self.tracks.genre)))
         if genre:
             info["genre"] = genre
 

--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -240,7 +240,7 @@ class Album(db.Entity):
         if count(self.tracks.year) > 0:
             info["year"] = min(self.tracks.year)
 
-        genre = ", ".join(list(set(self.tracks.genre)))
+        genre = ", ".join(self.tracks.genre.distinct())
         if genre:
             info["genre"] = genre
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,6 +19,7 @@ from .issue129 import Issue129TestCase
 from .issue133 import Issue133TestCase
 from .issue139 import Issue139TestCase
 from .issue148 import Issue148TestCase
+from .issue221 import Issue221TestCase
 
 
 def suite():
@@ -34,5 +35,6 @@ def suite():
     suite.addTest(unittest.makeSuite(Issue133TestCase))
     suite.addTest(unittest.makeSuite(Issue139TestCase))
     suite.addTest(unittest.makeSuite(Issue148TestCase))
+    suite.addTest(unittest.makeSuite(Issue221TestCase))
 
     return suite

--- a/tests/issue221.py
+++ b/tests/issue221.py
@@ -1,0 +1,53 @@
+# This file is part of Supysonic.
+# Supysonic is a Python implementation of the Subsonic server API.
+#
+# Copyright (C) 2021 Alban 'spl0k' Féron
+#
+# Distributed under terms of the GNU AGPLv3 license.
+
+import unittest
+
+from pony.orm import db_session
+
+from supysonic import db
+
+
+class Issue221TestCase(unittest.TestCase):
+    def setUp(self):
+        db.init_database("sqlite:")
+        with db_session:
+            root = db.Folder(root=True, name="Folder", path="tests")
+            artist = db.Artist(name="Artist")
+            album = db.Album(artist=artist, name="Album")
+
+            for i in range(3):
+                db.Track(
+                    title="Track {}".format(i),
+                    album=album,
+                    artist=artist,
+                    disc=1,
+                    number=i + 1,
+                    duration=3,
+                    has_art=False,
+                    bitrate=64,
+                    path="tests/track{}".format(i),
+                    last_modification=2,
+                    root_folder=root,
+                    folder=root,
+                    genre="Genre",
+                )
+
+            db.User(name="user", password="secret", salt="sugar")
+
+    def tearDown(self):
+        db.release_database()
+
+    @db_session
+    def test_issue(self):
+        data = db.Album.get().as_subsonic_album(db.User.get())
+        self.assertIn("genre", data)
+        self.assertEqual(data["genre"], "Genre")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR merges duplicate track genre tags when constructing the album genre info. This change will help players which display the album genre to avoid cluttering their display with a repeated list of identical genre names. This idea came from https://github.com/peguerosdc/subplayer/issues/48