### PR TITLE
Fix listing album tracks without track number

### DIFF
--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -318,8 +318,8 @@ class Album(_Model):
 
 class Track(PathMixin, _Model):
     id = PrimaryKeyField()
-    disc = IntegerField()
-    number = IntegerField()
+    disc = IntegerField(null=True)
+    number = IntegerField(null=True)
     title = CharField()
     year = IntegerField(null=True)
     genre = CharField(null=True)
@@ -350,7 +350,7 @@ class Track(PathMixin, _Model):
             "title": self.title,
             "album": self.album.name,
             "artist": self.artist.name,
-            "track": self.number,
+            "track": self.number or "",
             "size": os.path.getsize(self.path) if os.path.isfile(self.path) else -1,
             "contentType": self.mimetype,
             "suffix": self.suffix(),
@@ -358,7 +358,7 @@ class Track(PathMixin, _Model):
             "bitRate": self.bitrate,
             "path": self.path[len(self.root_folder.path) + 1 :],
             "isVideo": False,
-            "discNumber": self.disc,
+            "discNumber": self.disc or "",
             "created": self.created.isoformat(),
             "albumId": str(self.album.id),
             "artistId": str(self.artist.id),
@@ -421,7 +421,7 @@ class Track(PathMixin, _Model):
         return os.path.splitext(self.path)[1][1:].lower()
 
     def sort_key(self):
-        return f"{self.album.artist.name}{self.album.name}{self.disc:02}{self.number:02}{self.title}".lower()
+        return f"{self.album.artist.name}{self.album.name}{self.disc:02 or ''}{self.number:02 or ''}{self.title}".lower()
 
 
 class User(_Model):

--- a/supysonic/schema/mysql.sql
+++ b/supysonic/schema/mysql.sql
@@ -25,8 +25,8 @@ CREATE INDEX index_album_artist_id_fk ON album(artist_id);
 
 CREATE TABLE IF NOT EXISTS track (
     id CHAR(32) PRIMARY KEY,
-    disc INTEGER NOT NULL,
-    number INTEGER NOT NULL,
+    disc INTEGER,
+    number INTEGER,
     title VARCHAR(256) NOT NULL,
     year INTEGER,
     genre VARCHAR(256),

--- a/supysonic/schema/postgres.sql
+++ b/supysonic/schema/postgres.sql
@@ -25,8 +25,8 @@ CREATE INDEX IF NOT EXISTS index_album_artist_id_fk ON album(artist_id);
 
 CREATE TABLE IF NOT EXISTS track (
     id UUID PRIMARY KEY,
-    disc INTEGER NOT NULL,
-    number INTEGER NOT NULL,
+    disc INTEGER,
+    number INTEGER,
     title CITEXT NOT NULL,
     year INTEGER,
     genre VARCHAR(256),

--- a/supysonic/schema/sqlite.sql
+++ b/supysonic/schema/sqlite.sql
@@ -26,8 +26,8 @@ CREATE INDEX IF NOT EXISTS index_album_artist_id_fk ON album(artist_id);
 
 CREATE TABLE IF NOT EXISTS track (
     id CHAR(36) PRIMARY KEY,
-    disc INTEGER NOT NULL,
-    number INTEGER NOT NULL,
+    disc INTEGER,
+    number INTEGER,
     title VARCHAR(256) NOT NULL COLLATE NOCASE,
     year INTEGER,
     genre VARCHAR(256),


### PR DESCRIPTION
This fixes an issue when listing "albums" that are just folders with tracks that don't have a disk or track number, so the listing becomes out of order.