### PR TITLE
Make log rotation optional

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -29,6 +29,9 @@ log_file = /var/supysonic/supysonic.log
 ; Default: WARNING
 log_level = WARNING
 
+; Enable log rotation. Default: yes
+log_rotate = yes
+
 ; Enable the Subsonic REST API. You'll most likely want to keep this on, here
 ; for testing purposes. Default: on
 ;mount_api = on
@@ -60,6 +63,7 @@ jukebox_command = mplayer -ss %offset %path
 ; Optional rotating log file for the scanner daemon. Logs to stderr if empty
 log_file = /var/supysonic/supysonic-daemon.log
 log_level = INFO
+log_rotate = yes
 
 [lastfm]
 ; API and secret key to enable scrobbling. http://www.last.fm/api/accounts

--- a/supysonic/config.py
+++ b/supysonic/config.py
@@ -34,6 +34,7 @@ class DefaultConfig:
         "transcode_cache_size": 512,
         "log_file": None,
         "log_level": "WARNING",
+        "log_rotate": True,
         "mount_webui": True,
         "mount_api": True,
         "index_ignored_prefixes": "El La Le Las Les Los The",
@@ -47,6 +48,7 @@ class DefaultConfig:
         "jukebox_command": None,
         "log_file": None,
         "log_level": "WARNING",
+        "log_rotate": True,
     }
     LASTFM = {"api_key": None, "secret": None}
     TRANSCODING = {}

--- a/supysonic/daemon/__init__.py
+++ b/supysonic/daemon/__init__.py
@@ -25,10 +25,10 @@ daemon = None
 
 def setup_logging(config):
     if config["log_file"]:
-        if config["log_file"] == "/dev/null":
-            log_handler = logging.NullHandler()
-        else:
+        if config["log_rotate"]:
             log_handler = TimedRotatingFileHandler(config["log_file"], when="midnight")
+        else:
+            log_handler = logging.FileHandler(config["log_file"])
         log_handler.setFormatter(
             logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
         )

--- a/supysonic/web.py
+++ b/supysonic/web.py
@@ -11,6 +11,7 @@ import logging
 import mimetypes
 
 from flask import Flask
+from logging.handlers import TimedRotatingFileHandler
 from os import makedirs, path
 
 from .config import IniConfig
@@ -35,9 +36,10 @@ def create_application(config=None):
     # Set loglevel
     logfile = app.config["WEBAPP"]["log_file"]
     if logfile:  # pragma: nocover
-        from logging.handlers import TimedRotatingFileHandler
-
-        handler = TimedRotatingFileHandler(logfile, when="midnight")
+        if app.config["WEBAPP"]["log_rotate"]:
+            handler = TimedRotatingFileHandler(logfile, when="midnight")
+        else:
+            handler = logging.FileHandler(logfile)
         handler.setFormatter(
             logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
         )


### PR DESCRIPTION
This disables the log rotation feature, so people can use external utilities like logrotate.