### PR TITLE
Fix bitrate units when scanning and add a DB migration to fix existing tracks

### DIFF
--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -31,7 +31,7 @@ from playhouse.db_url import parseresult_to_dict, schemes
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
-SCHEMA_VERSION = "20230115"
+SCHEMA_VERSION = "20230331"
 
 
 def now():

--- a/supysonic/scanner.py
+++ b/supysonic/scanner.py
@@ -239,7 +239,7 @@ class Scanner(Thread):
         trdict["duration"] = int(tag.length)
         trdict["has_art"] = bool(tag.images)
 
-        trdict["bitrate"] = tag.bitrate
+        trdict["bitrate"] = tag.bitrate // 1000
         trdict["last_modification"] = mtime
 
         tralbum = self.__find_album(albumartist, album)

--- a/supysonic/schema/migration/mysql/20230331.sql
+++ b/supysonic/schema/migration/mysql/20230331.sql
@@ -1,0 +1,5 @@
+START TRANSACTION;
+
+UPDATE track SET bitrate=bitrate/1000 WHERE bitrate > 16000 AND path NOT LIKE '%.wav';
+
+COMMIT;

--- a/supysonic/schema/migration/postgres/20230331.sql
+++ b/supysonic/schema/migration/postgres/20230331.sql
@@ -1,0 +1,5 @@
+START TRANSACTION;
+
+UPDATE track SET bitrate=bitrate/1000 WHERE bitrate > 16000 AND path NOT LIKE '%.wav';
+
+COMMIT;

--- a/supysonic/schema/migration/sqlite/20230331.sql
+++ b/supysonic/schema/migration/sqlite/20230331.sql
@@ -1,0 +1,8 @@
+COMMIT;
+PRAGMA foreign_keys = OFF;
+BEGIN TRANSACTION;
+
+UPDATE track SET bitrate=bitrate/1000 WHERE bitrate > 16000 AND path NOT LIKE '%.wav';
+
+COMMIT;
+BEGIN TRANSACTION;

--- a/tests/base/test_scanner.py
+++ b/tests/base/test_scanner.py
@@ -70,6 +70,22 @@ class ScannerTestCase(unittest.TestCase):
         self.scanner.scan_file("/some/inexistent/path")
         self.assertEqual(db.Track.select().count(), 1)
 
+    def test_scanned_metadata(self):
+        self.assertEqual(db.Track.select().count(), 1)
+
+        track = db.Track.select().first()
+        artist = db.Artist.select().where(db.Artist.id == track.artist).first()
+        album = db.Album.select().where(db.Album.id == track.album).first()
+
+        self.assertEqual(track.bitrate, 128)
+        self.assertEqual(track.disc, 1)
+        self.assertEqual(track.number, 1)
+        self.assertEqual(track.duration, 4)
+        self.assertEqual(track.has_art, True)
+        self.assertEqual(track.title, "[silence]")
+        self.assertEqual(artist.name, "Some artist")
+        self.assertEqual(album.name, "Awesome album")
+
     def test_remove_file(self):
         track = db.Track.select().first()
         self.assertRaises(TypeError, self.scanner.remove_file, None)


### PR DESCRIPTION
In 0183bcb6 the scanner switched from using Mutagen to Mediafile for scanning files. Prior to this commit, the bitrate from Mutagen was divided by 1000 to convert it from bps to kbps. After switching to Mediafile, the conversion was dropped even though Mediafile also reports bitrate in bps.

This PR adds back the conversion to kbps, adds a test that checks that the bitrate and some other metadata is correct, as well as a database migration that should fix up any existing errors.

The database migration will find all tracks that don't end with `.wav` (case-insensitive) and have a bitrate > 16000 and divide their bitrate by 1000. I have tested the migration using sqlite, but **have not tested it with postgres or mysql**.

Fixing this issue will also fix transcoding being applied in some cases where it isn't needed. In fact, I originally discovered this because I noticed an mp3 at 128kbps was being transcoded while I was streaming it, even though it fell well under my configured maximum bitrate. The reason it was being transcoded was because the bitrate in the DB was always larger than the requested bitrate due to it being in bps vs. kbps.