### PR TITLE
Replace distutils.dir_util.remove_tree() by shutil.rmtree().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 
 import os.path
 
-from distutils import dir_util
+from shutil import rmtree
 from setuptools import setup
 from setuptools.command.sdist import sdist as _sdist
 
@@ -19,7 +19,7 @@ class sdist(_sdist):
         man_dir = os.path.join(base_dir, "man")
         doctrees_dir = os.path.join(man_dir, ".doctrees")
         self.spawn(["sphinx-build", "-q", "-b", "man", "docs", man_dir])
-        dir_util.remove_tree(doctrees_dir)
+        rmtree(doctrees_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Python 3.10 and 3.11, distutils has been formally marked as deprecated. Code that imports distutils will no longer work from Python 3.12.

I'm pretty sure distutils.dir_util.remove_tree() and shutil.rmtree() do the same exact same thing and this should fix the issue :)