### PR TITLE
Fix track duration display

### DIFF
--- a/supysonic/db.py
+++ b/supysonic/db.py
@@ -412,9 +412,11 @@ class Track(PathMixin, _Model):
         return mimetypes.guess_type(self.path, False)[0] or "application/octet-stream"
 
     def duration_str(self):
-        ret = f"{(self.duration % 3600) / 60:02}:{self.duration % 60:02}"
-        if self.duration >= 3600:
-            ret = f"{self.duration / 3600:02}:{ret}"
+        m, s = divmod(self.duration, 60)
+        h, m = divmod(m, 60)
+        ret = f"{m:02}:{s:02}"
+        if h:
+            ret = f"{h:02}:{ret}"
         return ret
 
     def suffix(self):

--- a/tests/base/test_db.py
+++ b/tests/base/test_db.py
@@ -59,7 +59,7 @@ class DbTestCase(unittest.TestCase):
             artist=artist,
             disc=1,
             number=1,
-            duration=3,
+            duration=3599,
             has_art=True,
             bitrate=320,
             path="tests/assets/formats/silence.ogg",
@@ -74,7 +74,7 @@ class DbTestCase(unittest.TestCase):
             artist=artist,
             disc=1,
             number=2,
-            duration=5,
+            duration=3600,
             bitrate=96,
             path="tests/assets/23bytes",
             last_modification=1234,
@@ -222,6 +222,9 @@ class DbTestCase(unittest.TestCase):
 
     def test_track(self):
         track1, track2 = self.create_some_tracks()
+
+        assert track1.duration_str() == "59:59"
+        assert track2.duration_str() == "01:00:00"
 
         # Assuming SQLite doesn't enforce foreign key constraints
         MockUser = namedtuple("User", ["id"])


### PR DESCRIPTION
This fixes decimal places appearing in track durations. Currently this is only shown in the playlists UI:
| Before | After |
| -| -- |
| ![before](https://github.com/user-attachments/assets/2e7e1ee1-8982-43b0-8810-f42c11c73a52) | ![after](https://github.com/user-attachments/assets/52920d4c-e5ba-48e0-8d1d-ae58af465aa7) |

Also added some very basic tests to check durations around the hour boundary are properly handled.