### PR TITLE
Fixes changemail POST

### DIFF
--- a/supysonic/frontend/user.py
+++ b/supysonic/frontend/user.py
@@ -182,6 +182,7 @@ def change_mail_post(uid, user):
     mail = request.form.get("mail", "")
     # No validation, lol.
     user.mail = mail
+    user.save()
     return redirect(url_for("frontend.user_profile", uid=uid))
 
 


### PR DESCRIPTION
As mentioned in #267 it is not possible to change the email address in any way, neither of your own user nor, being admin, of any other user.

This happens simply because the change is not saved in the function that handles the `POST` in `changemail`.