### PR TITLE
Fix 20251030 migration (#272)

### DIFF
--- a/supysonic/schema/migration/mysql/20251030.py
+++ b/supysonic/schema/migration/mysql/20251030.py
@@ -33,12 +33,13 @@ def apply(args):
             c.execute(query)
         conn.commit()
 
-        c.execute("SELECT id, tracks FROM playlist")
-        for id, tracks in c:
+        c2 = conn.cursor()
+        c2.execute("SELECT id, tracks FROM playlist")
+        for id, tracks in c2:
             params = []
             for idx, trackid in enumerate(tracks.split(",")):
                 params.append((uuid.uuid4().hex, id, uuid.UUID(trackid).hex, idx))
-            sql = "INSERT INTO playlist_track(id, playlist_id, track_id, `index`) VALUES(%s, %s, %s, %s)"
+            sql = "INSERT IGNORE INTO playlist_track(id, playlist_id, track_id, `index`) VALUES(%s, %s, %s, %s)"
             c.executemany(sql, params)
         conn.commit()
 

--- a/supysonic/schema/migration/postgres/20251030.py
+++ b/supysonic/schema/migration/postgres/20251030.py
@@ -30,12 +30,13 @@ def apply(args):
             c.execute(query)
         conn.commit()
 
-        c.execute("SELECT id, tracks FROM playlist")
-        for id, tracks in c.fetchall():
+        c2 = conn.cursor()
+        c2.execute("SELECT id, tracks FROM playlist")
+        for id, tracks in c2:
             params = []
             for idx, trackid in enumerate(tracks.split(",")):
                 params.append((uuid.uuid4(), id, uuid.UUID(trackid), idx))
-            sql = 'INSERT INTO playlist_track(id, playlist_id, track_id, "index") VALUES(%s, %s, %s, %s)'
+            sql = 'INSERT INTO playlist_track(id, playlist_id, track_id, "index") VALUES(%s, %s, %s, %s) ON CONFLICT DO NOTHING'
             c.executemany(sql, params)
         conn.commit()
 

--- a/supysonic/schema/migration/sqlite/20251030.py
+++ b/supysonic/schema/migration/sqlite/20251030.py
@@ -31,11 +31,13 @@ def apply(args):
             c.execute(query)
         conn.commit()
 
-        for id, tracks in c.execute("SELECT id, tracks FROM playlist"):
+        c2 = conn.cursor()
+        c2.execute("SELECT id, tracks FROM playlist")
+        for id, tracks in c2:
             params = []
             for idx, trackid in enumerate(tracks.split(",")):
                 params.append((uuid.uuid4().hex, id, uuid.UUID(trackid).hex, idx))
-            sql = 'INSERT INTO playlist_track(id, playlist_id, track_id, "index") VALUES(?, ?, ?, ?)'
+            sql = 'INSERT OR IGNORE INTO playlist_track(id, playlist_id, track_id, "index") VALUES(?, ?, ?, ?)'
             c.executemany(sql, params)
         conn.commit()
 


### PR DESCRIPTION
Watch out those cursor reuses! The migration was only migrating the first playlist, leaving all other playlists empty. It's also better to use `IGNORE` for the SQL queries, so any missing track ID will just be ignored. I only tested with SQLite.

#272